### PR TITLE
Downgrade nodejs version

### DIFF
--- a/modules/home-manager/neovim/default.nix
+++ b/modules/home-manager/neovim/default.nix
@@ -16,7 +16,7 @@ _:
       extraLuaConfig = builtins.readFile ./init.lua;
     };
 
-    home.packages = with pkgs; [ tree-sitter gcc nodejs ];
+    home.packages = with pkgs; [ tree-sitter gcc nodejs-16_x ];
 
     xdg.configFile.nvim = {
       source = ./config;


### PR DESCRIPTION
Some neovim LSP fail because of nodejs 18
