### PR TITLE
chore: Update flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -195,11 +195,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692260837,
-        "narHash": "sha256-2FpkX1zl+7ni7djK7NeE1ZGupRUwZgjW+RPCSBgDf4k=",
+        "lastModified": 1692503956,
+        "narHash": "sha256-MOA6FKc1YgfGP3ESnjSYfsyJ1BXlwV5pGlY/u5XdJfY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6a94c1a59737783c282c4031555a289c28b961e4",
+        "rev": "958c06303f43cf0625694326b7f7e5475b1a2d5c",
         "type": "github"
       },
       "original": {
@@ -218,11 +218,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1692388511,
-        "narHash": "sha256-klXDm3hl62w3xoToLKmwbIbPAZ3j/B9iZWg6fx2Och0=",
+        "lastModified": 1692574189,
+        "narHash": "sha256-bPiITKG5fFB5vzx28sC9cfcz+BkfJGe2W5ZoiFiRUtA=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "5a6c7c805b8bb1d1ed9fe829ed33f18ffa6f4f47",
+        "rev": "694814cdd54ac245d1f4d2c28dce7e9132fcb616",
         "type": "github"
       },
       "original": {
@@ -243,11 +243,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692403508,
-        "narHash": "sha256-968Kk7DiDlOHSBSmMdzCP45IPUkScjLniQNCSIKi65s=",
+        "lastModified": 1692576342,
+        "narHash": "sha256-eIJqMmicuB93qQd38YIRW2v/0GczYzNN57Xf/rNZJTY=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "f0f52faaf2af2ab492b3d03ce294437266cdf497",
+        "rev": "76577f17abb193cb77d786a932aa1f78a8dcfa5a",
         "type": "github"
       },
       "original": {
@@ -263,11 +263,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1691897365,
-        "narHash": "sha256-jvWIU4ht3YAmF8TDVM2Ps2+Gf4MtNGLL1zEWQZdTrzU=",
+        "lastModified": 1692503351,
+        "narHash": "sha256-FdG0wnizM9mAUgi58KP1tXaX4ogVooPDS6VwsGEqZ9s=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "f4d70d098f066a30c7087144063dca179495f7d6",
+        "rev": "4becac130db930e9de8c3fe58bfa245c119b9eeb",
         "type": "github"
       },
       "original": {
@@ -333,11 +333,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1692356644,
-        "narHash": "sha256-AYkPFT+CbCVSBmh0WwIzPpwhEJ4Yy3A7JZvUkGJIg5o=",
+        "lastModified": 1692447944,
+        "narHash": "sha256-fkJGNjEmTPvqBs215EQU4r9ivecV5Qge5cF/QDLVn3U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8ecc900b2f695d74dea35a92f8a9f9b32c8ea33d",
+        "rev": "d680ded26da5cf104dd2735a51e88d2d8f487b4d",
         "type": "github"
       },
       "original": {
@@ -349,11 +349,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1692446373,
-        "narHash": "sha256-/XrcXEPVPD6O6TYL3K8GOTNMu6PrieFvFbpq8NDvfss=",
+        "lastModified": 1692601307,
+        "narHash": "sha256-+LQYdb78YRkkoCuJc9xV2qdMyEVlkdfEHqQKwfDc0VI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2eb627394f363f0494d07321c2c06a6a5a31686",
+        "rev": "728cd1f35f4cc3a0e76a017f0f1d5b8137fc9d5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/6a94c1a59737783c282c4031555a289c28b961e4' (2023-08-17)
  → 'github:nix-community/home-manager/958c06303f43cf0625694326b7f7e5475b1a2d5c' (2023-08-20)
• Updated input 'neovim-nightly-overlay':
    'github:nix-community/neovim-nightly-overlay/f0f52faaf2af2ab492b3d03ce294437266cdf497' (2023-08-19)
  → 'github:nix-community/neovim-nightly-overlay/76577f17abb193cb77d786a932aa1f78a8dcfa5a' (2023-08-21)
• Updated input 'neovim-nightly-overlay/neovim-flake':
    'github:neovim/neovim/5a6c7c805b8bb1d1ed9fe829ed33f18ffa6f4f47?dir=contrib' (2023-08-18)
  → 'github:neovim/neovim/694814cdd54ac245d1f4d2c28dce7e9132fcb616?dir=contrib' (2023-08-20)
• Updated input 'nix-index-database':
    'github:Mic92/nix-index-database/f4d70d098f066a30c7087144063dca179495f7d6' (2023-08-13)
  → 'github:Mic92/nix-index-database/4becac130db930e9de8c3fe58bfa245c119b9eeb' (2023-08-20)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/8ecc900b2f695d74dea35a92f8a9f9b32c8ea33d' (2023-08-18)
  → 'github:nixos/nixpkgs/d680ded26da5cf104dd2735a51e88d2d8f487b4d' (2023-08-19)
• Updated input 'nur':
    'github:nix-community/NUR/c2eb627394f363f0494d07321c2c06a6a5a31686' (2023-08-19)
  → 'github:nix-community/NUR/728cd1f35f4cc3a0e76a017f0f1d5b8137fc9d5c' (2023-08-21)
