### PR TITLE
Bump flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -281,11 +281,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708558280,
-        "narHash": "sha256-w1ns8evB6N9VTrAojcdXLWenROtd77g3vyClrqeFdG8=",
+        "lastModified": 1708591310,
+        "narHash": "sha256-8mQGVs8JccWTnORgoLOTh9zvf6Np+x2JzhIc+LDcJ9s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0b69d574162cfa6eb7919d5614a48d0185550891",
+        "rev": "0e0e9669547e45ea6cca2de4044c1a384fd0fe55",
         "type": "github"
       },
       "original": {
@@ -345,11 +345,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1708553425,
-        "narHash": "sha256-ogPsU8uYLYHYQjk9nsmH9FDqiVDaasGTfdH3A3xR+rk=",
+        "lastModified": 1708722750,
+        "narHash": "sha256-hgOLzcLadoG2fJzfoR+Aav1nF5+46TsjfJcOg62A12o=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "d9e6a442f2ff9aebf4d45ad6fb5b05d492eb4e38",
+        "rev": "99288ecc77e429ffe06842157e72ed612e97a419",
         "type": "github"
       },
       "original": {
@@ -370,11 +370,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708560234,
-        "narHash": "sha256-gq/eDLJG6uYq92kB8vnNPutI2ssfO9b9/ErtFSKD0ec=",
+        "lastModified": 1708733013,
+        "narHash": "sha256-sI2VzJDzkyphED2uy7kDfXPCRKXysyBo7mZ/qdddY64=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "a0b0165567b68194f6c0795dd6e3c3dd714b681f",
+        "rev": "587d1f1c3c23ccb18b39388f76f082d3ee24f328",
         "type": "github"
       },
       "original": {
@@ -467,11 +467,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708475490,
-        "narHash": "sha256-g1v0TsWBQPX97ziznfJdWhgMyMGtoBFs102xSYO4syU=",
+        "lastModified": 1708655239,
+        "narHash": "sha256-ZrP/yACUvDB+zbqYJsln4iwotbH6CTZiTkANJ0AgDv4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e74ca98a74bc7270d28838369593635a5db3260",
+        "rev": "cbc4211f0afffe6dfd2478a62615dd5175a13f9a",
         "type": "github"
       },
       "original": {
@@ -540,11 +540,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1708595872,
-        "narHash": "sha256-0y7y1oOrsUXRHET/y9PagCHXI29e/uKp61Quos3XhEE=",
+        "lastModified": 1708614940,
+        "narHash": "sha256-36muWApzetaV4WAEeqKsWxW4k2l0u3E841RI4sHPiz0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "5870c2e964b5da5bf04b39d540fac49ece1ac143",
+        "rev": "060a05138ca1a46fc0a0f79ef27f080cac57a59e",
         "type": "github"
       },
       "original": {
@@ -555,11 +555,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708594103,
-        "narHash": "sha256-tHGO5E1LYZ8BsiYYBAcA28cAXe5ttU0xTVTmgSiUsGk=",
+        "lastModified": 1708749495,
+        "narHash": "sha256-yCCmJIJFy9PMXraVAibkAsrJMEuMInC9gvKsQZz+f8s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2c086ffc6cd61ded1e6979fd425e08074e3d7ea",
+        "rev": "099272d8b84ddafe37e4f451bc27f554e00fca05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/0b69d574162cfa6eb7919d5614a48d0185550891' (2024-02-21)
  → 'github:nix-community/home-manager/0e0e9669547e45ea6cca2de4044c1a384fd0fe55' (2024-02-22)
• Updated input 'neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/a0b0165567b68194f6c0795dd6e3c3dd714b681f' (2024-02-22)
  → 'github:nix-community/neovim-nightly-overlay/587d1f1c3c23ccb18b39388f76f082d3ee24f328' (2024-02-24)
• Updated input 'neovim-nightly/neovim-flake':
    'github:neovim/neovim/d9e6a442f2ff9aebf4d45ad6fb5b05d492eb4e38?dir=contrib' (2024-02-21)
  → 'github:neovim/neovim/99288ecc77e429ffe06842157e72ed612e97a419?dir=contrib' (2024-02-23)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/0e74ca98a74bc7270d28838369593635a5db3260' (2024-02-21)
  → 'github:nixos/nixpkgs/cbc4211f0afffe6dfd2478a62615dd5175a13f9a' (2024-02-23)
• Updated input 'nixvim':
    'github:nix-community/nixvim/5870c2e964b5da5bf04b39d540fac49ece1ac143' (2024-02-22)
  → 'github:nix-community/nixvim/060a05138ca1a46fc0a0f79ef27f080cac57a59e' (2024-02-22)
• Updated input 'nur':
    'github:nix-community/NUR/a2c086ffc6cd61ded1e6979fd425e08074e3d7ea' (2024-02-22)
  → 'github:nix-community/NUR/099272d8b84ddafe37e4f451bc27f554e00fca05' (2024-02-24)