### PR TITLE
chore: Bump flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713204594,
-        "narHash": "sha256-5yyHYBWFZUKXkJvOccPBeX83hH2iED54NLnWs2eWgS0=",
+        "lastModified": 1713406758,
+        "narHash": "sha256-kwZvhmx+hSZvjzemKxsAqzEqWmXZS47VVwQhNrINORQ=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "d51114dc1bf3cfaba2b6644aabd16ff0c9909af5",
+        "rev": "1efd500e9805a9efbce401ed5999006d397b9f11",
         "type": "github"
       },
       "original": {
@@ -297,11 +297,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1712909959,
-        "narHash": "sha256-7/5ubuwdEbQ7Z+Vqd4u0mM5L2VMNDsBh54visp27CtQ=",
+        "lastModified": 1713377320,
+        "narHash": "sha256-OrBm62B+X9jylr6cPgKc+5OSgF2PRW9IY0ARCOtURMY=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "f58b25254be441cd2a9b4b444ed83f1e51244f1f",
+        "rev": "f2d364de6589f7a029624983593eafc3c4dac726",
         "type": "github"
       },
       "original": {
@@ -339,11 +339,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713294767,
-        "narHash": "sha256-LmaabaQZdx52MPGKPRt9Opoc9Gd9RbwvCdysUUYQoXI=",
+        "lastModified": 1713391096,
+        "narHash": "sha256-5xkzsy+ILgQlmvDDipL5xqAehnjWBenAQXV4/NLg2dE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fa8c16e2452bf092ac76f09ee1fb1e9f7d0796e7",
+        "rev": "f46814ec7cbef9c2aef18ca1cbe89f2bb1e8c394",
         "type": "github"
       },
       "original": {
@@ -403,11 +403,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1713307949,
-        "narHash": "sha256-hfiUG/nGWaPnYdiDXVHagVLoezxflWHdKiAtghkIHYc=",
+        "lastModified": 1713392591,
+        "narHash": "sha256-k7d4HX+HZgRGy6bGtZ5VjuhCrrBd3PoYvdwbeT34Mrs=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "2f371ad7d0294072d407bb05816425b5694d1935",
+        "rev": "562719033ec8bec9f6d56c166b9aef13f8a50a96",
         "type": "github"
       },
       "original": {
@@ -428,11 +428,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713312222,
-        "narHash": "sha256-81xZFNHBLV8+oD3Q3SkesXFLh2U1UFeGQBLw75moOh4=",
+        "lastModified": 1713398630,
+        "narHash": "sha256-mTW1HDy3630zZU/1TiKRmDi/TjiVLtg3BQlQD3hukJQ=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "542a3c18b471dbaaf8ffda27a65d3aa8e829a5e2",
+        "rev": "0357dd0ccc62d66bf3b916fb5c7409c92b5dbec7",
         "type": "github"
       },
       "original": {
@@ -614,11 +614,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1713344642,
-        "narHash": "sha256-fTkBHEiesChZWw/uLv/6f2V9+BmDddoXphtM+VZQ25U=",
+        "lastModified": 1713428541,
+        "narHash": "sha256-NyRSt7UAL5somK25jMl+L2HW2mMcZ1f15ANdmHZU1YM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6a4796465a21ad68f75d57b3b76bceebb66ada59",
+        "rev": "263715fe80866783b4158994de294e10cdc94d40",
         "type": "github"
       },
       "original": {
@@ -678,11 +678,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713174909,
-        "narHash": "sha256-APoDs2GtzVrsE+Z9w72qpHzEtEDfuinWcNTN7zhwLxg=",
+        "lastModified": 1713428550,
+        "narHash": "sha256-bHWNcnnlVzd1ek7uHoQQzFEM5lqscijCOgcz1uU766w=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "cc535d07cbcdd562bcca418e475c7b1959cefa4b",
+        "rev": "a9795d1959fe17a38bc901323d25f4e70acef511",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/d51114dc1bf3cfaba2b6644aabd16ff0c9909af5' (2024-04-15)
  → 'github:nix-community/disko/1efd500e9805a9efbce401ed5999006d397b9f11' (2024-04-18)
• Updated input 'hardware':
    'github:nixos/nixos-hardware/f58b25254be441cd2a9b4b444ed83f1e51244f1f' (2024-04-12)
  → 'github:nixos/nixos-hardware/f2d364de6589f7a029624983593eafc3c4dac726' (2024-04-17)
• Updated input 'home-manager':
    'github:nix-community/home-manager/fa8c16e2452bf092ac76f09ee1fb1e9f7d0796e7' (2024-04-16)
  → 'github:nix-community/home-manager/f46814ec7cbef9c2aef18ca1cbe89f2bb1e8c394' (2024-04-17)
• Updated input 'neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/542a3c18b471dbaaf8ffda27a65d3aa8e829a5e2' (2024-04-17)
  → 'github:nix-community/neovim-nightly-overlay/0357dd0ccc62d66bf3b916fb5c7409c92b5dbec7' (2024-04-18)
• Updated input 'neovim-nightly/neovim-flake':
    'github:neovim/neovim/2f371ad7d0294072d407bb05816425b5694d1935?dir=contrib' (2024-04-16)
  → 'github:neovim/neovim/562719033ec8bec9f6d56c166b9aef13f8a50a96?dir=contrib' (2024-04-17)
• Updated input 'nur':
    'github:nix-community/NUR/6a4796465a21ad68f75d57b3b76bceebb66ada59' (2024-04-17)
  → 'github:nix-community/NUR/263715fe80866783b4158994de294e10cdc94d40' (2024-04-18)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/cc535d07cbcdd562bcca418e475c7b1959cefa4b' (2024-04-15)
  → 'github:Mic92/sops-nix/a9795d1959fe17a38bc901323d25f4e70acef511' (2024-04-18)
