### PR TITLE
feat: Add `arch` package

### DIFF
--- a/modules/home-manager/terminal/cli/default.nix
+++ b/modules/home-manager/terminal/cli/default.nix
@@ -103,6 +103,7 @@
     };
 
     home.packages = with pkgs; [
+      arch
       bc
       boot-status
       bottom

--- a/pkgs/arch/arch.sh
+++ b/pkgs/arch/arch.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+lscpu | grep Architecture | cut -d ":" -f2 | tr -d " "

--- a/pkgs/arch/default.nix
+++ b/pkgs/arch/default.nix
@@ -1,0 +1,20 @@
+{ lib
+, writeShellApplication
+, coreutils
+, util-linux
+,
+}:
+(writeShellApplication {
+  name = "arch";
+  runtimeInputs = [
+    coreutils
+    util-linux
+  ];
+  text = builtins.readFile ./arch.sh;
+})
+  // {
+  meta = with lib; {
+    licenses = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -5,6 +5,7 @@ let
   firefox-addons = import ./firefox-addons { inherit (pkgs) fetchurl stdenv lib; };
   callPackage = pkgs.lib.callPackageWith (pkgs // packages);
   packages = {
+    arch = callPackage ./arch { };
     boot-status = callPackage ./boot-status { };
     configure-gtk = callPackage ./configure-gtk { };
     flameshot-grim = callPackage ./flameshot { };


### PR DESCRIPTION
It's a simple ad-hoc implementation because uutils-coreutils-noprefix adds a lot of binaries, and not all of them work as expected
