### PR TITLE
chore: Bump flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734701201,
-        "narHash": "sha256-hk0roBX10j/hospoWIJIJj3i2skd7Oml6yKQBx7mTFk=",
+        "lastModified": 1735468753,
+        "narHash": "sha256-2dt1nOe9zf9pDkf5Kn7FUFyPRo581s0n90jxYXJ94l0=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "2ee76c861af3b895b3b104bae04777b61397485b",
+        "rev": "84a5b93637cc16cbfcc61b6e1684d626df61eb21",
         "type": "github"
       },
       "original": {
@@ -309,11 +309,11 @@
     },
     "hardware": {
       "locked": {
-        "lastModified": 1734954597,
-        "narHash": "sha256-QIhd8/0x30gEv8XEE1iAnrdMlKuQ0EzthfDR7Hwl+fk=",
+        "lastModified": 1735388221,
+        "narHash": "sha256-e5IOgjQf0SZcFCEV/gMGrsI0gCJyqOKShBQU0iiM3Kg=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "def1d472c832d77885f174089b0d34854b007198",
+        "rev": "7c674c6734f61157e321db595dbfcd8523e04e19",
         "type": "github"
       },
       "original": {
@@ -351,11 +351,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734944412,
-        "narHash": "sha256-36QfCAl8V6nMIRUCgiC79VriJPUXXkHuR8zQA1vAtSU=",
+        "lastModified": 1735381016,
+        "narHash": "sha256-CyCZFhMUkuYbSD6bxB/r43EdmDE7hYeZZPTCv0GudO4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8264bfe3a064d704c57df91e34b795b6ac7bad9e",
+        "rev": "10e99c43cdf4a0713b4e81d90691d22c6a58bdf2",
         "type": "github"
       },
       "original": {
@@ -431,11 +431,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1734942015,
-        "narHash": "sha256-7qj3Hk2NMiWdBNk3E3T6GdHkMDUCWK0kz10P9Jl6z58=",
+        "lastModified": 1735517129,
+        "narHash": "sha256-ibHgAkr8OXAP8MRBo4Z7AIaVdOHywGR2J8R50vZCQjI=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "38f1d0177de284cb54045b3e888d66cd4710ce5a",
+        "rev": "fd381a5a19f553c2466dc437fb94fcf799d77e82",
         "type": "github"
       },
       "original": {
@@ -447,11 +447,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1734887107,
-        "narHash": "sha256-h5U1/by2ikiPBUPCTbWAMALCy+DTkjt6Fs8nepY44/4=",
+        "lastModified": 1735489459,
+        "narHash": "sha256-PMeWazyxGxpA6UeVrWH/ur8WuqliGxXlRjTTQdMiYVc=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "665a0e85c4788cb2847e270c333c0aee306f07ad",
+        "rev": "e4bc8b5967d22840c1e52c97acab0f77107cd48c",
         "type": "github"
       },
       "original": {
@@ -486,11 +486,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734838217,
-        "narHash": "sha256-zvMLS8BGn+kMG7tLLT3PJ67/S9yqZ9B7V8hKBa9cRRY=",
+        "lastModified": 1735443188,
+        "narHash": "sha256-AydPpRBh8+NOkrLylG7vTsHrGO2b5L7XkMEL5HlzcA8=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "d583b2d142f0428313df099f4a2dcf2a0496aa78",
+        "rev": "55ab1e1df5daf2476e6b826b69a82862dcbd7544",
         "type": "github"
       },
       "original": {
@@ -501,11 +501,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734649271,
-        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
+        "lastModified": 1735471104,
+        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
         "type": "github"
       },
       "original": {
@@ -564,11 +564,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1734649271,
-        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
+        "lastModified": 1735471104,
+        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
         "type": "github"
       },
       "original": {
@@ -633,11 +633,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1734979259,
-        "narHash": "sha256-jIW45i9kC83Go/3yY7VWvzQgCVi79LdNoK7xzZ4hvgQ=",
+        "lastModified": 1735543962,
+        "narHash": "sha256-+2yRRwemiUXtC7Xrv9lJY5ScCXF7GjYHi4Fz5ADHEts=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9352dd122ce26f1c482aaeeb55ab057b9f84008b",
+        "rev": "be4ede4b588b7b879d393caf6eba9e040586ecb3",
         "type": "github"
       },
       "original": {
@@ -824,11 +824,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1734546875,
-        "narHash": "sha256-6OvJbqQ6qPpNw3CA+W8Myo5aaLhIJY/nNFDk3zMXLfM=",
+        "lastModified": 1735468296,
+        "narHash": "sha256-ZjUjbvS06jf4fElOF4ve8EHjbpbRVHHypStoY8HGzk8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "ed091321f4dd88afc28b5b4456e0a15bd8374b4d",
+        "rev": "bcb8b65aa596866eb7e5c3e1a6cccbf5d1560b27",
         "type": "github"
       },
       "original": {
@@ -890,11 +890,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734704479,
-        "narHash": "sha256-MMi74+WckoyEWBRcg/oaGRvXC9BVVxDZNRMpL+72wBI=",
+        "lastModified": 1735135567,
+        "narHash": "sha256-8T3K5amndEavxnludPyfj3Z1IkcFdRpR23q+T0BVeZE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "65712f5af67234dad91a5a4baee986a8b62dbf8f",
+        "rev": "9e09d30a644c57257715902efbb3adc56c79cf28",
         "type": "github"
       },
       "original": {
@@ -1003,11 +1003,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1734913862,
-        "narHash": "sha256-C73hSei9ly+/BMXWqAaMJdG/r+qZWzSbwqfSTsEtdv4=",
+        "lastModified": 1735432382,
+        "narHash": "sha256-Nmo+nId69rTNgkLQI5l920S8EiBLDeaBW88Pb45hte4=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "fb9bc7cd50913b741f1d66aedca8a07583cc5f53",
+        "rev": "639f18e72540fe1f46bcdedf37c90dd9131cda6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'disko':
    'github:nix-community/disko/2ee76c861af3b895b3b104bae04777b61397485b?narHash=sha256-hk0roBX10j/hospoWIJIJj3i2skd7Oml6yKQBx7mTFk%3D' (2024-12-20)
  → 'github:nix-community/disko/84a5b93637cc16cbfcc61b6e1684d626df61eb21?narHash=sha256-2dt1nOe9zf9pDkf5Kn7FUFyPRo581s0n90jxYXJ94l0%3D' (2024-12-29)
• Updated input 'hardware':
    'github:nixos/nixos-hardware/def1d472c832d77885f174089b0d34854b007198?narHash=sha256-QIhd8/0x30gEv8XEE1iAnrdMlKuQ0EzthfDR7Hwl%2Bfk%3D' (2024-12-23)
  → 'github:nixos/nixos-hardware/7c674c6734f61157e321db595dbfcd8523e04e19?narHash=sha256-e5IOgjQf0SZcFCEV/gMGrsI0gCJyqOKShBQU0iiM3Kg%3D' (2024-12-28)
• Updated input 'home-manager':
    'github:nix-community/home-manager/8264bfe3a064d704c57df91e34b795b6ac7bad9e?narHash=sha256-36QfCAl8V6nMIRUCgiC79VriJPUXXkHuR8zQA1vAtSU%3D' (2024-12-23)
  → 'github:nix-community/home-manager/10e99c43cdf4a0713b4e81d90691d22c6a58bdf2?narHash=sha256-CyCZFhMUkuYbSD6bxB/r43EdmDE7hYeZZPTCv0GudO4%3D' (2024-12-28)
• Updated input 'neovim-nightly':
    'github:nix-community/neovim-nightly-overlay/38f1d0177de284cb54045b3e888d66cd4710ce5a?narHash=sha256-7qj3Hk2NMiWdBNk3E3T6GdHkMDUCWK0kz10P9Jl6z58%3D' (2024-12-23)
  → 'github:nix-community/neovim-nightly-overlay/fd381a5a19f553c2466dc437fb94fcf799d77e82?narHash=sha256-ibHgAkr8OXAP8MRBo4Z7AIaVdOHywGR2J8R50vZCQjI%3D' (2024-12-30)
• Updated input 'neovim-nightly/neovim-src':
    'github:neovim/neovim/665a0e85c4788cb2847e270c333c0aee306f07ad?narHash=sha256-h5U1/by2ikiPBUPCTbWAMALCy%2BDTkjt6Fs8nepY44/4%3D' (2024-12-22)
  → 'github:neovim/neovim/e4bc8b5967d22840c1e52c97acab0f77107cd48c?narHash=sha256-PMeWazyxGxpA6UeVrWH/ur8WuqliGxXlRjTTQdMiYVc%3D' (2024-12-29)
• Updated input 'neovim-nightly/treefmt-nix':
    'github:numtide/treefmt-nix/65712f5af67234dad91a5a4baee986a8b62dbf8f?narHash=sha256-MMi74%2BWckoyEWBRcg/oaGRvXC9BVVxDZNRMpL%2B72wBI%3D' (2024-12-20)
  → 'github:numtide/treefmt-nix/9e09d30a644c57257715902efbb3adc56c79cf28?narHash=sha256-8T3K5amndEavxnludPyfj3Z1IkcFdRpR23q%2BT0BVeZE%3D' (2024-12-25)
• Updated input 'nix-index-database':
    'github:Mic92/nix-index-database/d583b2d142f0428313df099f4a2dcf2a0496aa78?narHash=sha256-zvMLS8BGn%2BkMG7tLLT3PJ67/S9yqZ9B7V8hKBa9cRRY%3D' (2024-12-22)
  → 'github:Mic92/nix-index-database/55ab1e1df5daf2476e6b826b69a82862dcbd7544?narHash=sha256-AydPpRBh8%2BNOkrLylG7vTsHrGO2b5L7XkMEL5HlzcA8%3D' (2024-12-29)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d70bd19e0a38ad4790d3913bf08fcbfc9eeca507?narHash=sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ%3D' (2024-12-19)
  → 'github:nixos/nixpkgs/88195a94f390381c6afcdaa933c2f6ff93959cb4?narHash=sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs%3D' (2024-12-29)
• Updated input 'nur':
    'github:nix-community/NUR/9352dd122ce26f1c482aaeeb55ab057b9f84008b?narHash=sha256-jIW45i9kC83Go/3yY7VWvzQgCVi79LdNoK7xzZ4hvgQ%3D' (2024-12-23)
  → 'github:nix-community/NUR/be4ede4b588b7b879d393caf6eba9e040586ecb3?narHash=sha256-%2B2yRRwemiUXtC7Xrv9lJY5ScCXF7GjYHi4Fz5ADHEts%3D' (2024-12-30)
• Updated input 'nur/nixpkgs':
    'github:nixos/nixpkgs/d70bd19e0a38ad4790d3913bf08fcbfc9eeca507?narHash=sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ%3D' (2024-12-19)
  → 'github:nixos/nixpkgs/88195a94f390381c6afcdaa933c2f6ff93959cb4?narHash=sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs%3D' (2024-12-29)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/ed091321f4dd88afc28b5b4456e0a15bd8374b4d?narHash=sha256-6OvJbqQ6qPpNw3CA%2BW8Myo5aaLhIJY/nNFDk3zMXLfM%3D' (2024-12-18)
  → 'github:Mic92/sops-nix/bcb8b65aa596866eb7e5c3e1a6cccbf5d1560b27?narHash=sha256-ZjUjbvS06jf4fElOF4ve8EHjbpbRVHHypStoY8HGzk8%3D' (2024-12-29)
• Updated input 'zig':
    'github:mitchellh/zig-overlay/fb9bc7cd50913b741f1d66aedca8a07583cc5f53?narHash=sha256-C73hSei9ly%2B/BMXWqAaMJdG/r%2BqZWzSbwqfSTsEtdv4%3D' (2024-12-23)
  → 'github:mitchellh/zig-overlay/639f18e72540fe1f46bcdedf37c90dd9131cda6d?narHash=sha256-Nmo%2BnId69rTNgkLQI5l920S8EiBLDeaBW88Pb45hte4%3D' (2024-12-29)
