### PR TITLE
feat(szaffarano-elastic): reorganize services

### DIFF
--- a/modules/home-manager/desktop/messengers/default.nix
+++ b/modules/home-manager/desktop/messengers/default.nix
@@ -12,10 +12,12 @@ in
     config = mkIf cfg.enable {
       home = {
         custom.allowed-unfree-packages = with pkgs; [
+          zoom-us
           slack
           telegram-desktop
         ];
         packages = with pkgs; [
+          zoom-us
           slack
           telegram-desktop
         ];

--- a/system/zaffarano-elastic/default.nix
+++ b/system/zaffarano-elastic/default.nix
@@ -2,6 +2,7 @@
   inputs,
   config,
   flakeRoot,
+  pkgs,
   ...
 }: let
   userName = "szaffarano";
@@ -63,8 +64,28 @@ in {
       "yubikey"
     ];
   };
-  services.greetd.enable = false;
-  services.flatpak.enable = true;
+  services = {
+    ananicy = {
+      enable = true;
+      package = pkgs.ananicy-cpp;
+      extraRules = [
+        {
+          name = "elastic-endpoin";
+          nice = 10;
+        }
+        {
+          name = "elastic-endpoint";
+          nice = 10;
+        }
+        {
+          name = "elastic-agent";
+          nice = 10;
+        }
+      ];
+    };
+    greetd.enable = false;
+    flatpak.enable = false;
+  };
 
   networking = {
     inherit hostName;

--- a/users/szaffarano/zaffarano-elastic.nix
+++ b/users/szaffarano/zaffarano-elastic.nix
@@ -52,12 +52,14 @@
     wayland.compositors.hyprland.enable = false;
     wayland.compositors.sway.enable = true;
   };
-  services.flameshot = {
-    enable = false;
-    package = pkgs.flameshot-grim;
+  services = {
+    flameshot = {
+      enable = false;
+      package = pkgs.flameshot-grim;
+    };
+    syncthing.enable = true;
   };
   terminal.cli.cloud.enable = true;
-  services.syncthing.enable = true;
   programs.nix-index.enable = true;
   develop = {
     enable = true;


### PR DESCRIPTION
- Added zoom-us to allowed-unfree-packages and packages in home manager
  messengers default configuration.
- Reorganized services block in zaffarano-elastic.nix for better structure.
- Disable flatpak
- Configure ananicy
