### PR TITLE
feat(pkgs): add get-keepass-entry utility script

### DIFF
--- a/modules/home-manager/desktop/tools/keepassxc/default.nix
+++ b/modules/home-manager/desktop/tools/keepassxc/default.nix
@@ -28,6 +28,6 @@ in
         config.desktop.wayland.compositors.hyprland.enable && cfg.autostart
       ) ["${pkgs.keepassxc}/bin/keepassxc"];
 
-      home.packages = with pkgs; [keepassxc];
+      home.packages = with pkgs; [keepassxc get-keepass-entry];
     };
   }

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -23,6 +23,7 @@
     cliphist-to-wofi = callPackage ./cliphist-to-wofi {};
     configure-gtk = callPackage ./configure-gtk {};
     flameshot-grim = callPackage ./flameshot {};
+    get-keepass-entry = callPackage ./get-keepass-entry {};
     lock-screen = callPackage ./lock-screen {};
     sync-lid = callPackage ./sync-lid {};
     resurrect-hyprlock = callPackage ./resurrect-hyprlock {};

--- a/pkgs/get-keepass-entry/default.nix
+++ b/pkgs/get-keepass-entry/default.nix
@@ -1,0 +1,16 @@
+{
+  lib,
+  writeShellApplication,
+  coreutils,
+}:
+(writeShellApplication {
+  name = "get-keepass-entry";
+  runtimeInputs = [coreutils];
+  text = builtins.readFile ./get-keepass-entry.sh;
+})
+// {
+  meta = with lib; {
+    licenses = licenses.mit;
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/get-keepass-entry/get-keepass-entry.sh
+++ b/pkgs/get-keepass-entry/get-keepass-entry.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+username=$1
+url=$2
+
+if [ $# -eq 2 ]; then
+	printf "url=%s\nusername=%s\n" "$url" "$username" |
+		git-credential-keepassxc --unlock 0 get |
+		sed -n 's/^password=//p'
+else
+	exit 1
+fi


### PR DESCRIPTION
Add a new shell application 'get-keepass-entry' for retrieving passwords
from keepassxc via git-credential-keepassxc. The script takes a username and
URL, unlocks the credential store, and outputs the associated password.

Also update home-manager keepassxc module to include this utility in the
home.packages list.

This enhances credential management by enabling quick programmatic access
to keepassxc entries.
