### PR TITLE
fix(lint, keymaps): correct diagnostic toggling and navigation keys

### DIFF
--- a/modules/home-manager/terminal/editors/nvim/config/lua/sebas/plugins/lint.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/lua/sebas/plugins/lint.lua
@@ -22,11 +22,7 @@ return {
         callback = function(event)
           require('lint').try_lint()
           local function toggle_diagnostic()
-            if vim.diagnostic.is_disabled(event.buf) then
-              vim.diagnostic.enable(event.buf)
-            else
-              vim.diagnostic.disable(event.buf)
-            end
+            vim.diagnostic.enable(not vim.diagnostic.is_enabled())
           end
           vim.keymap.set({ 'n', 'v' }, '<F2>', toggle_diagnostic, { buffer = event.buf, desc = 'Toggle diagnostic' })
         end,

--- a/modules/home-manager/terminal/editors/nvim/config/plugin/autocmds.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/plugin/autocmds.lua
@@ -3,7 +3,10 @@ vim.api.nvim_create_autocmd('TextYankPost', {
   desc = 'Highlight when yanking (copying) text',
   group = vim.api.nvim_create_augroup('highlight-yank', { clear = true }),
   callback = function()
-    vim.highlight.on_yank()
+    vim.hl.on_yank {
+      higroup = 'Visual',
+      timeout = 100,
+    }
   end,
 })
 

--- a/modules/home-manager/terminal/editors/nvim/config/plugin/keymaps.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/plugin/keymaps.lua
@@ -5,8 +5,8 @@ vim.opt.hlsearch = true
 vim.keymap.set('n', '<Esc>', '<cmd>nohlsearch<CR>')
 
 -- Diagnostic keymaps
-vim.keymap.set('n', '[d', vim.diagnostic.goto_prev, { desc = 'Go to previous [D]iagnostic message' })
-vim.keymap.set('n', ']d', vim.diagnostic.goto_next, { desc = 'Go to next [D]iagnostic message' })
+vim.keymap.set('n', '[d', vim.lsp.diagnostic.goto_prev, { desc = 'Go to previous [D]iagnostic message' })
+vim.keymap.set('n', ']d', vim.lsp.diagnostic.goto_next, { desc = 'Go to next [D]iagnostic message' })
 vim.keymap.set('n', '<leader>e', vim.diagnostic.open_float, { desc = 'Show diagnostic [E]rror messages' })
 vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, { desc = 'Open diagnostic [Q]uickfix list' })
 


### PR DESCRIPTION
Refactor diagnostic toggle logic to properly enable diagnostics. Update
diagnostic navigation keymaps to use vim.lsp.diagnostic for compatibility.
Also enhance yank highlight settings by specifying highlight group and
timeout for better visual feedback.
