### PR TITLE
fix(keymaps): update diagnostic navigation to new API

### DIFF
--- a/modules/home-manager/terminal/editors/nvim/config/plugin/keymaps.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/plugin/keymaps.lua
@@ -5,8 +5,12 @@ vim.opt.hlsearch = true
 vim.keymap.set('n', '<Esc>', '<cmd>nohlsearch<CR>')
 
 -- Diagnostic keymaps
-vim.keymap.set('n', '[d', vim.lsp.diagnostic.goto_prev, { desc = 'Go to previous [D]iagnostic message' })
-vim.keymap.set('n', ']d', vim.lsp.diagnostic.goto_next, { desc = 'Go to next [D]iagnostic message' })
+vim.keymap.set('n', '[d', function()
+  vim.diagnostic.jump { count = -1 }
+end, { desc = 'Go to previous [D]iagnostic message' })
+vim.keymap.set('n', ']d', function()
+  vim.diagnostic.jump { count = 1 }
+end, { desc = 'Go to next [D]iagnostic message' })
 vim.keymap.set('n', '<leader>e', vim.diagnostic.open_float, { desc = 'Show diagnostic [E]rror messages' })
 vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, { desc = 'Open diagnostic [Q]uickfix list' })
 


### PR DESCRIPTION
Replace deprecated vim.lsp.diagnostic.goto_prev/next with
vim.diagnostic.jump function calls for navigating previous and next
diagnostic messages.
