### PR TITLE
fix(nvim): move DiagnosticChanged autocmd to plugin autocommands

### DIFF
--- a/modules/home-manager/terminal/editors/nvim/config/after/ftplugin/rust.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/after/ftplugin/rust.lua
@@ -33,12 +33,6 @@ vim.keymap.set('n', '<leader>E', function()
   vim.cmd.RustLsp { 'explainError', 'current' }
 end, { buffer = bufnr, desc = 'Explain [E]rror (Rust)' })
 
-vim.api.nvim_create_autocmd('DiagnosticChanged', {
-  callback = function()
-    vim.diagnostic.setqflist { open = false }
-  end,
-})
-
 -- mappings to review:
 -- vim.cmd.RustLsp('relatedDiagnostics')
 -- vim.cmd.RustLsp('openCargo')

--- a/modules/home-manager/terminal/editors/nvim/config/plugin/autocmds.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/plugin/autocmds.lua
@@ -50,3 +50,10 @@ vim.api.nvim_create_autocmd('User', {
     end
   end,
 })
+
+-- Populate diagnostics to the quickfix list
+vim.api.nvim_create_autocmd('DiagnosticChanged', {
+  callback = function()
+    vim.diagnostic.setqflist { open = false }
+  end,
+})


### PR DESCRIPTION
Moved the DiagnosticChanged autocmd from rust ftplugin to a general
autocmds plugin config. This ensures diagnostics are populated to the
quickfix list across all filetypes consistently.
