### PR TITLE
docs: add AGENTS.md for AI assistants using this repo

### DIFF
--- a/.github/workflows/nix-checks.yml
+++ b/.github/workflows/nix-checks.yml
@@ -1,5 +1,10 @@
-name: Nix code analysis
-on: [push]
+name: CI | Nix checks
+on:
+  push:
+    paths:
+      - '**/*.nix'
+      - 'flake.lock'
+      - 'flake.nix'
 jobs:
   deadnix:
     name: Deadnix

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI | generic checks
 on:
   pull_request:
   push:
@@ -6,14 +6,6 @@ on:
       - master
       - develop
 jobs:
-  # pre-commit:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-python@v3
-  #     - uses: pre-commit/action@v3.0.1
-  #       with:
-  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
   check:
     runs-on: ubuntu-latest
     permissions:
@@ -27,5 +19,7 @@ jobs:
           extra-conf: |
             extra-platforms = aarch64-linux
       - uses: DeterminateSystems/flakehub-cache-action@main
-      - run: nix flake check
-      - run: nix flake show
+      - name: Run pre-commit checks via Nix
+        run: nix flake check
+      - name: Show flake outputs
+        run: nix flake show

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,83 @@
+# AGENTS.md
+
+This file provides guidance for agentic coding agents working with this NixOS
+dotfiles repository.
+
+## Repository Overview
+
+This is a NixOS-based dotfiles repository using flakes for declarative system
+and home-manager configurations. The repository manages multiple machines and
+users with encrypted secrets using SOPS.
+
+## Project Structure
+
+- `system/` — System configuration, including infra setups.
+- `modules/nixos/` — NixOS modules for system configurations.
+- `modules/home-manager/` — Home Manager modules for user configurations.
+- `overlays` — Nixpkgs overlays for custom package definitions.
+- `pkgs/` — Package definitions for NixOS and Home Manager.
+- `users/` — User-specific configurations, including Home Manager setups.
+
+### Key Components
+
+- **Flake inputs**: Manages dependencies like nixpkgs, home-manager, sops-nix,
+  disko
+- **System configurations**: NixOS setups for bock, weisse, zaffarano-elastic,
+  pilsen, lambic (RPi)
+- **Home configurations**: User environments with desktop/development tools
+- **SOPS integration**: Encrypted secrets management with age keys
+- **Disko**: Declarative disk partitioning and formatting
+- **Pre-commit hooks**: Automated formatting and linting (deadnix, alejandra,
+  ruff, etc.)
+
+### Machine Types
+
+- Desktop/laptop systems (bock, weisse, pilsen, zaffarano-elastic)
+- Raspberry Pi system (lambic) with ARM64 support
+- Development shells for various environments
+
+## Build/Lint/Test Commands
+
+- `nix fmt` — Format all files using treefmt (alejandra for Nix, ruff for
+  Python, shfmt for shell)
+- `nix flake check` — Run all checks including pre-commit hooks (deadnix,
+  statix, ruff, pyright, etc.)
+- `nix develop` — Enter development shell with all tools
+- `nix build '.#nixosConfigurations.<hostname>.config.system.build.toplevel'` —
+  Build system configuration
+- `sudo nixos-rebuild switch --flake .#<hostname>` — Apply system configuration
+- `home-manager switch --flake .` — Apply home-manager configuration.
+
+## Code Style Guidelines
+
+### Nix Files
+
+- Use alejandra formatter (2-space indentation)
+- Remove dead code with deadnix
+- Follow existing module structure: `{ imports = [ ./submodules ]; }`
+- Use `lib.mkIf`, `lib.mkDefault`, `lib.mkForce` for conditionals
+- Prefer `with pkgs;` sparingly, explicit `pkgs.package` is better
+
+### Python Files
+
+- Use ruff for formatting and linting
+- Type hints required (pyright checking enabled)
+- Follow PEP 8 conventions
+
+### Shell Scripts
+
+- Use `#!/usr/bin/env bash` shebang
+- Include `set -euo pipefail` for safety
+- Format with shfmt (2-space indentation)
+
+### Secret Management Workflow
+
+1. Generate SSH keys for new machines
+1. Convert to age format with ssh-to-age
+1. Update `.sops.yaml` with new recipients
+1. Create/edit secrets files with `sops`
+1. Reference secrets in system configurations
+
+When working with this repository, always use the flake-based commands and
+respect the existing directory structure. System changes require sudo
+privileges, while home-manager changes run as the user.


### PR DESCRIPTION
Add documentation file with guidance for agentic coding assistants to
help them understand the repository structure, build commands, and code
style guidelines.
