### PR TITLE
chore(pkgs): update opencode to v0.3.46 and vectorcode to v0.7.9

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -15,12 +15,12 @@
 
   vectorcode = final: prev: {
     vectorcode = prev.vectorcode.overridePythonAttrs (_old: rec {
-      version = "0.7.7";
+      version = "0.7.9";
       src = final.fetchFromGitHub {
         owner = "Davidyz";
         repo = "VectorCode";
         tag = version;
-        hash = "sha256-c8Wp/bP5KHDN/i2bMyiOQgnHDw8tPbg4IZIQ5Ut4SIo=";
+        hash = "sha256-EU/JitByOXfquMCcMHH14gCbVl/oHpREAcQNxmOuI+E=";
       };
       pythonRelaxDeps = [
         "posthog"

--- a/pkgs/opencode/default.nix
+++ b/pkgs/opencode/default.nix
@@ -18,12 +18,12 @@
 in
   stdenvNoCC.mkDerivation (finalAttrs: {
     pname = "opencode";
-    version = "0.3.43";
+    version = "0.3.46";
     src = fetchFromGitHub {
       owner = "sst";
       repo = "opencode";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-EM44FkMPPkRChuLcNEEK3n4dLc5uqnX7dHROsZXyr58=";
+      hash = "sha256-3Jm1rSp82kOk7DNvTZQMa+/xiMV1S8roN09NvPXrTNg=";
     };
 
     tui = buildGoModule {
@@ -31,7 +31,7 @@ in
       inherit (finalAttrs) version;
       src = "${finalAttrs.src}/packages/tui";
 
-      vendorHash = "sha256-/YxvM+HZM4aRqcjUiSX0D1DhhMJkmLdh7G4+fPqtnic=";
+      vendorHash = "sha256-MZAKEXA34dHiH4XYUlLq6zo8ppG8JD3nj7fhZMrr+TI=";
 
       subPackages = ["cmd/opencode"];
 


### PR DESCRIPTION
🤖 Generated with [opencode](https://opencode.ai)

Co-Authored-By: opencode <noreply@opencode.ai>
