### PR TITLE
feat(power): add TLP power management and fix Sway floating rules

### DIFF
--- a/modules/home-manager/desktop/wayland/compositors/sway/floating-criteria.nix
+++ b/modules/home-manager/desktop/wayland/compositors/sway/floating-criteria.nix
@@ -3,8 +3,14 @@ _: {
     wayland.windowManager.sway.config.floating.criteria = [
       {app_id = "org.pulseaudio.pavucontrol";}
       {app_id = "zenity";}
-      {title = "Settings";}
-      {class = "zoom";}
+      {
+        title = "Settings";
+        app_id = "^(?!firefox$).*";
+      }
+      {
+        class = "zoom";
+        app_id = "^(?!firefox$).*";
+      }
       {app_id = "nm-connection-editor";}
       {app_id = "blueberry.py";}
       {app_id = "transmission-qt";}

--- a/modules/nixos/global/system/power.nix
+++ b/modules/nixos/global/system/power.nix
@@ -15,10 +15,13 @@
     )
     devices;
 in {
-  environment.systemPackages = with pkgs; [
-    fwupd
-    libsmbios
-  ];
+  environment.systemPackages = with pkgs;
+    [
+      fwupd
+    ]
+    ++ lib.optionals pkgs.stdenv.hostPlatform.isx86 [
+      libsmbios
+    ];
 
   services = {
     tlp = {

--- a/modules/nixos/global/system/power.nix
+++ b/modules/nixos/global/system/power.nix
@@ -15,7 +15,62 @@
     )
     devices;
 in {
+  environment.systemPackages = with pkgs; [
+    fwupd
+    libsmbios
+  ];
+
+  services = {
+    tlp = {
+      enable = true;
+      settings = {
+        # Default mode (auto-switch)
+        TLP_DEFAULT_MODE = "AC";
+        TLP_PERSISTENT_DEFAULT = 0;
+
+        # CPU scaling
+        CPU_SCALING_GOVERNOR_ON_AC = "performance";
+        CPU_SCALING_GOVERNOR_ON_BAT = "powersave";
+
+        # Intel P-state performance limits
+        CPU_MIN_PERF_ON_AC = 50;
+        CPU_MAX_PERF_ON_AC = 100;
+        CPU_MIN_PERF_ON_BAT = 20;
+        CPU_MAX_PERF_ON_BAT = 60;
+
+        # Turbo Boost
+        CPU_BOOST_ON_AC = 1;
+        CPU_BOOST_ON_BAT = 0;
+
+        # Platform profile
+        PLATFORM_PROFILE_ON_AC = "performance";
+        PLATFORM_PROFILE_ON_BAT = "balanced";
+
+        # Disk and PCIe
+        DISK_APM_LEVEL_ON_AC = 254;
+        DISK_APM_LEVEL_ON_BAT = 128;
+        SATA_LINKPWR_ON_AC = "max_performance";
+        SATA_LINKPWR_ON_BAT = "min_power";
+        PCIE_ASPM_ON_AC = "performance";
+        PCIE_ASPM_ON_BAT = "powersave";
+
+        # USB autosuspend
+        USB_AUTOSUSPEND = 0;
+
+        # Runtime power management
+        RUNTIME_PM_ON_AC = "on";
+        RUNTIME_PM_ON_BAT = "auto";
+
+        # Dell SMBIOS battery thresholds (BIOS-level)
+        START_CHARGE_THRESH_BAT0 = 50;
+        STOP_CHARGE_THRESH_BAT0 = 80;
+      };
+    };
+  };
   systemd.services = lib.mkIf (lidName != "") {
+    thermald.enable = true;
+    powerManagement.enable = true;
+
     "${actionAction}-${lidName}" = lib.mkIf (lidName != null) {
       wantedBy = ["multi-user.target"];
       description = "${actionAction} wakeup on opening LID0";

--- a/system/zaffarano-elastic/hardware-configuration.nix
+++ b/system/zaffarano-elastic/hardware-configuration.nix
@@ -38,7 +38,7 @@
   networking.useDHCP = lib.mkDefault true;
 
   # Often used values: “ondemand”, “powersave”, “performance”
-  powerManagement.cpuFreqGovernor = lib.mkDefault "performance";
+  # powerManagement.cpuFreqGovernor = lib.mkDefault "performance";
   hardware.cpu.intel.updateMicrocode = true;
 
   nixpkgs.hostPlatform = "x86_64-linux";

--- a/system/zaffarano-elastic/hardware-configuration.nix
+++ b/system/zaffarano-elastic/hardware-configuration.nix
@@ -37,8 +37,6 @@
 
   networking.useDHCP = lib.mkDefault true;
 
-  # Often used values: “ondemand”, “powersave”, “performance”
-  # powerManagement.cpuFreqGovernor = lib.mkDefault "performance";
   hardware.cpu.intel.updateMicrocode = true;
 
   nixpkgs.hostPlatform = "x86_64-linux";


### PR DESCRIPTION
## Summary

- Add comprehensive TLP power management with Dell-specific optimizations including battery charge thresholds, CPU scaling governors, and thermal management for improved battery life and performance
- Fix Sway floating window criteria to prevent Firefox settings dialogs from incorrectly floating by adding app_id exclusions

## Test plan

- [x] Verify TLP service starts correctly on system boot
- [x] Test power profile switching between AC and battery modes
- [x] Confirm battery charge thresholds are applied (50-80% range)
- [x] Validate CPU scaling governors change appropriately (performance on AC, powersave on battery)
- [x] Test Sway window floating behavior with Firefox settings dialogs
- [x] Verify other applications' settings dialogs still float correctly (non-Firefox)
- [x] Check thermal management and fan behavior under load
