### PR TITLE
feat(git): add git-lfs package to home-manager configuration

### DIFF
--- a/modules/home-manager/terminal/cli/git.nix
+++ b/modules/home-manager/terminal/cli/git.nix
@@ -43,6 +43,8 @@ in {
       git = lib.mkIf config.programs.git.enable {
         package = pkgs.gitFull;
 
+        lfs.enable = true;
+
         aliases = {
           br = "branch";
           ci = "commit";


### PR DESCRIPTION
## Summary
- Add git-lfs package to the home-manager git configuration
- Enables Git LFS (Large File Storage) support in the development environment

## Test plan
- [x] Verify git-lfs is available in the environment after applying the configuration
- [x] Test git-lfs functionality with a sample large file