### PR TITLE
feat: add jujutsu support and improve nvim folding

### DIFF
--- a/modules/home-manager/terminal/cli/default.nix
+++ b/modules/home-manager/terminal/cli/default.nix
@@ -9,9 +9,10 @@
     ./direnv.nix
     ./git.nix
     ./gpg.nix
-    ./spotify.nix
+    ./jujutsu.nix
     ./net.nix
     ./pass.nix
+    ./spotify.nix
     ./ssh.nix
     ./starship.nix
     ./tmux

--- a/modules/home-manager/terminal/cli/jujutsu.nix
+++ b/modules/home-manager/terminal/cli/jujutsu.nix
@@ -1,0 +1,16 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.terminal.cli.jujutsu;
+in
+  with lib; {
+    options.terminal.cli.jujutsu.enable = mkEnableOption "jujutsu";
+    config = mkIf cfg.enable {
+      programs.jujutsu = {
+        enable = true;
+        ediff = false;
+      };
+    };
+  }

--- a/modules/home-manager/terminal/editors/nvim/config/lua/sebas/plugins/ufo.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/lua/sebas/plugins/ufo.lua
@@ -50,6 +50,7 @@ end
 local ftMap = {
   yaml = { 'treesitter', 'indent' },
   org = { 'treesitter', 'indent' },
+  markdown = { 'treesitter', 'indent' },
 }
 
 return {

--- a/modules/nixos/users/sebas.nix
+++ b/modules/nixos/users/sebas.nix
@@ -76,7 +76,11 @@ in {
               user = {
                 inherit email;
                 name = "Sebastián Zaffarano";
-                # signing.key = lib.mkIf hasGpgKeys (builtins.elemAt userGpgKeys 0);
+              };
+              signing = {
+                sign-all = true;
+                backend = "gpg";
+                key = lib.mkIf hasGpgKeys (builtins.elemAt userGpgKeys 0);
               };
             };
           };

--- a/modules/nixos/users/sebas.nix
+++ b/modules/nixos/users/sebas.nix
@@ -78,7 +78,7 @@ in {
                 name = "Sebastián Zaffarano";
               };
               signing = {
-                sign-all = true;
+                behavior = "own";
                 backend = "gpg";
                 key = lib.mkIf hasGpgKeys (builtins.elemAt userGpgKeys 0);
               };

--- a/modules/nixos/users/sebas.nix
+++ b/modules/nixos/users/sebas.nix
@@ -71,6 +71,16 @@ in {
             };
           };
 
+          jujutsu = {
+            settings = {
+              user = {
+                inherit email;
+                name = "Sebastián Zaffarano";
+                # signing.key = lib.mkIf hasGpgKeys (builtins.elemAt userGpgKeys 0);
+              };
+            };
+          };
+
           git = {
             enable = true;
             userEmail = email;

--- a/users/szaffarano/zaffarano-elastic.nix
+++ b/users/szaffarano/zaffarano-elastic.nix
@@ -29,7 +29,10 @@
     };
     syncthing.enable = true;
   };
-  terminal.cli.cloud.enable = true;
+  terminal.cli = {
+    cloud.enable = true;
+    jujutsu.enable = true;
+  };
   programs.nix-index.enable = true;
   develop = {
     enable = true;


### PR DESCRIPTION
## Summary
- Add jujutsu version control system configuration module
- Enable jujutsu for zaffarano-elastic user with proper user settings
- Configure nvim ufo plugin to support markdown folding

## Test plan
- Verify jujutsu configuration is properly applied to home-manager
- Test markdown folding functionality in nvim
- Ensure all pre-commit hooks pass