### PR TITLE
chore: Remove zwift

### DIFF
--- a/system/zaffarano-elastic/default.nix
+++ b/system/zaffarano-elastic/default.nix
@@ -63,7 +63,6 @@ in {
       "syncthing"
       "virtualisation"
       "yubikey"
-      "zwift"
     ];
   };
   security.pam.services = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a single configuration toggle is removed, affecting only whether `zwift`-related setup is enabled on this host.
> 
> **Overview**
> Removes `"zwift"` from `nixos.custom.features.enable` in `system/zaffarano-elastic/default.nix`, disabling any `zwift`-related NixOS configuration for this machine.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bc9fa8ebee9ec0d73aa50f0c5448218ba18b7c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->