### PR TITLE
chore: Power-off screen after one hour

### DIFF
--- a/modules/home-manager/desktop/wayland/swayidle/default.nix
+++ b/modules/home-manager/desktop/wayland/swayidle/default.nix
@@ -65,7 +65,7 @@ in
               let
                 hyprctl = lib.getExe config.wayland.windowManager.hyprland.package;
               in {
-                timeout = 60;
+                timeout = 60 * 60;
                 command = "${hyprctl} dispatch dpms off";
                 resumeCommand = "${hyprctl} dispatch dpms on";
               }
@@ -74,7 +74,7 @@ in
           ++
           # Turn off displays (sway)
           (lib.optionals config.wayland.windowManager.sway.enable (afterLockTimeout {
-            timeout = 60;
+            timeout = 60 * 60;
             command = "${swaymsg} 'output * dpms off'";
             resumeCommand = "${swaymsg} 'output * dpms on'";
           }));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Simple constant change to idle DPMS timing; low risk aside from altering user-visible power/lock behavior.
> 
> **Overview**
> Adjusts `swayidle` display power management so screens are turned off after **one hour** of idle time instead of **60 seconds**.
> 
> This updates both Hyprland (`hyprctl dispatch dpms off/on`) and Sway (`swaymsg output * dpms off/on`) timeout values from `60` to `60 * 60`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb4cc1caed928e00bb9c9e603db0057ff006345b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->