### PR TITLE
chore: Update mise conf

### DIFF
--- a/modules/home-manager/develop/mise/default.nix
+++ b/modules/home-manager/develop/mise/default.nix
@@ -30,12 +30,10 @@ in {
         tools = {
           java = "temurin-25.0.0+36.0.LTS";
           node = "lts";
-          opencode = "latest";
           python = "latest";
           ruff = "latest";
           terraform = "latest";
           tflint = "latest";
-          gemini = "latest";
         };
       };
     };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config change that only removes two `mise` tool installations (`opencode`, `gemini`) and doesn’t affect runtime logic or data handling.
> 
> **Overview**
> Updates the `mise` Home Manager configuration to stop installing `opencode` and `gemini` via the global `tools` list, leaving the remaining language/tool versions unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e2d80d0cc123b0327abf7ced5896c363590c13c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->