### PR TITLE
chore: Add bun

### DIFF
--- a/modules/home-manager/develop/mise/default.nix
+++ b/modules/home-manager/develop/mise/default.nix
@@ -28,6 +28,7 @@ in {
           gpg_verify = false;
         };
         tools = {
+          bun = "latest";
           java = "temurin-25.0.0+36.0.LTS";
           node = "lts";
           python = "latest";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small configuration-only change that adds `bun` to the default `mise` tool list, with no changes to runtime logic or data handling.
> 
> **Overview**
> Adds `bun = "latest"` to the Home Manager `mise` `globalConfig.tools` defaults, so `bun` is installed/managed alongside the existing dev toolchain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6741e18b4e070a796b36d02aaaf048a52cc973b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->