### PR TITLE
chore: sway brightness, zig support, nvim fixes

### DIFF
--- a/modules/home-manager/desktop/wayland/compositors/sway/keybindings.nix
+++ b/modules/home-manager/desktop/wayland/compositors/sway/keybindings.nix
@@ -97,6 +97,9 @@
       "XF86AudioNext" = "exec playerctl next";
       "XF86AudioPrev" = "exec playerctl previous";
 
+      "XF86MonBrightnessUp" = "exec brightnessctl set +5%";
+      "XF86MonBrightnessDown" = "exec brightnessctl set 5%-";
+
       "${modifier}+Control_L+Left" = "move workspace to output left";
       "${modifier}+Control_L+Right" = "move workspace to output right";
 

--- a/modules/home-manager/develop/zig/default.nix
+++ b/modules/home-manager/develop/zig/default.nix
@@ -12,7 +12,7 @@ in
     config = with pkgs;
       lib.mkIf cfg.enable {
         home = {
-          packages = [zigpkgs.default];
+          packages = [zigpkgs.master];
         };
       };
   }

--- a/modules/home-manager/terminal/editors/nvim/config/after/ftplugin/mdx.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/after/ftplugin/mdx.lua
@@ -1,1 +1,0 @@
-vim.bo.filetype = 'markdown'

--- a/modules/home-manager/terminal/editors/nvim/config/after/ftplugin/zig.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/after/ftplugin/zig.lua
@@ -1,0 +1,21 @@
+-- Auto-apply all fixable zls diagnostics on save
+vim.api.nvim_create_autocmd('BufWritePre', {
+  buffer = 0,
+  callback = function()
+    vim.lsp.buf.code_action {
+      context = { only = { 'source.fixAll' }, diagnostics = {} },
+      apply = true,
+    }
+  end,
+})
+
+-- Auto-sort imports on save
+vim.api.nvim_create_autocmd('BufWritePre', {
+  buffer = 0,
+  callback = function()
+    vim.lsp.buf.code_action {
+      context = { only = { 'source.organizeImports' }, diagnostics = {} },
+      apply = true,
+    }
+  end,
+})

--- a/modules/home-manager/terminal/editors/nvim/config/after/lsp/bashls.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/after/lsp/bashls.lua
@@ -7,7 +7,5 @@ return {
     'bash-language-server',
     'start',
   },
-  settings = {
-    filetypes = { 'sh', 'zsh', 'bash' },
-  },
+  filetypes = { 'sh', 'zsh', 'bash' },
 }

--- a/modules/home-manager/terminal/editors/nvim/config/after/lsp/zls.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/after/lsp/zls.lua
@@ -1,0 +1,20 @@
+---@type vim.lsp.Config
+return {
+  root_markers = { 'build.zig', 'build.zig.zon' },
+  settings = {
+    zls = {
+      -- Report naming convention violations (e.g. snake_case for fns, PascalCase for types)
+      warn_style = true,
+      -- Highlight mutable global `var` declarations — Zig discourages them
+      highlight_global_var_declarations = true,
+      -- Hide redundant inlay hints where the arg name matches the param (e.g. `foo: foo`)
+      inlay_hints_hide_redundant_param_names = true,
+      -- Also hide when the last field/identifier matches (e.g. `foo: bar.foo`)
+      inlay_hints_hide_redundant_param_names_last_token = true,
+      -- Enable real compiler diagnostics via `zig build check`.
+      -- Only useful if your project has a `check` step in build.zig; zls auto-detects
+      -- it, but set explicitly to true if you always want it forced on.
+      -- enable_build_on_save = true,
+    },
+  },
+}

--- a/modules/home-manager/terminal/editors/nvim/config/init.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/init.lua
@@ -1,7 +1,5 @@
 require 'sebas.bootstrap'
 
-local is_vscode = vim.g.vscode ~= nil
-
 vim.g.base16_colorspace = 256
 vim.g.base16_background_transparent = 1
 

--- a/modules/home-manager/terminal/editors/nvim/config/lua/sebas/bootstrap.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/lua/sebas/bootstrap.lua
@@ -4,7 +4,7 @@ vim.g.maplocalleader = ' '
 
 -- [[ Install `lazy.nvim` plugin manager ]]
 local lazypath = vim.fn.stdpath 'data' .. '/lazy/lazy.nvim'
-if not vim.loop.fs_stat(lazypath) then
+if not vim.uv.fs_stat(lazypath) then
   local lazyrepo = 'https://github.com/folke/lazy.nvim.git'
   vim.fn.system { 'git', 'clone', '--filter=blob:none', '--branch=stable', lazyrepo, lazypath }
 end ---@diagnostic disable-next-line: undefined-field

--- a/modules/home-manager/terminal/editors/nvim/config/lua/sebas/lsp/init.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/lua/sebas/lsp/init.lua
@@ -101,6 +101,14 @@ vim.diagnostic.config {
   },
 }
 
+vim.lsp.config('*', {
+  capabilities = {
+    general = {
+      positionEncodings = { 'utf-16' },
+    },
+  },
+})
+
 vim.lsp.enable(servers)
 
 -- vim.cmd 'set completeopt+=noselect'

--- a/modules/home-manager/terminal/editors/nvim/config/lua/sebas/plugins/completion.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/lua/sebas/plugins/completion.lua
@@ -55,7 +55,7 @@ return {
         },
       },
 
-      fuzzy = { implementation = 'prefer_rust_with_warning' },
+      fuzzy = { implementation = 'prefer_rust' },
     },
     opts_extend = { 'sources.default' },
   },

--- a/modules/home-manager/terminal/editors/nvim/config/lua/sebas/plugins/harpoon.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/lua/sebas/plugins/harpoon.lua
@@ -39,10 +39,10 @@ return {
     end, { desc = 'Harpoon Window' })
 
     vim.keymap.set('n', '<C-n>', function()
-      harpoon:list():prev()
+      harpoon:list():next()
     end)
     vim.keymap.set('n', '<C-p>', function()
-      harpoon:list():next()
+      harpoon:list():prev()
     end)
   end,
 }

--- a/modules/home-manager/terminal/editors/nvim/config/lua/sebas/plugins/init.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/lua/sebas/plugins/init.lua
@@ -2,6 +2,5 @@ return {
   { 'tpope/vim-sleuth' },
   { 'jamessan/vim-gnupg' },
   { 'farmergreg/vim-lastplace' },
-  { 'numToStr/Comment.nvim', opts = {} },
   { 'windwp/nvim-autopairs', opts = {} },
 }

--- a/modules/home-manager/terminal/editors/nvim/config/lua/sebas/plugins/lint.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/lua/sebas/plugins/lint.lua
@@ -20,12 +20,17 @@ return {
       local lint_augroup = vim.api.nvim_create_augroup('lint', { clear = true })
       vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWritePost', 'InsertLeave' }, {
         group = lint_augroup,
-        callback = function(event)
+        callback = function()
           require('lint').try_lint()
-          local function toggle_diagnostic()
+        end,
+      })
+
+      vim.api.nvim_create_autocmd('BufEnter', {
+        group = lint_augroup,
+        callback = function(event)
+          vim.keymap.set({ 'n', 'v' }, '<F2>', function()
             vim.diagnostic.enable(not vim.diagnostic.is_enabled())
-          end
-          vim.keymap.set({ 'n', 'v' }, '<F2>', toggle_diagnostic, { buffer = event.buf, desc = 'Toggle diagnostic' })
+          end, { buffer = event.buf, desc = 'Toggle diagnostic' })
         end,
       })
 

--- a/modules/home-manager/terminal/editors/nvim/config/lua/sebas/plugins/markdown.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/lua/sebas/plugins/markdown.lua
@@ -1,9 +1,4 @@
-vim.filetype.add {
-  extension = { mdx = 'mdx' },
-}
-vim.treesitter.language.register('markdown', 'mdx')
-
-local file_types = { 'markdown', 'mdx', 'codecompanion', 'Avante' }
+local file_types = { 'markdown', 'codecompanion', 'Avante' }
 
 return {
   'MeanderingProgrammer/render-markdown.nvim',
@@ -29,6 +24,12 @@ return {
     },
   },
   ft = file_types,
+  init = function()
+    -- Map .mdx extension directly to markdown so LSP/treesitter/render-markdown
+    -- all activate without an intermediate 'mdx' filetype and the compound
+    -- 'markdown.mdx' health-check warning.
+    vim.filetype.add { extension = { mdx = 'markdown' } }
+  end,
   keys = {
     { '<F3>', '<CMD>RenderMarkdown toggle<CR>', desc = 'Render Markdown' },
   },

--- a/modules/home-manager/terminal/editors/nvim/config/lua/sebas/plugins/snacks.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/lua/sebas/plugins/snacks.lua
@@ -2,11 +2,7 @@ return {
   'folke/snacks.nvim',
   ---@type snacks.Config
   opts = {
-    input = {
-      b = {
-        completion = true,
-      },
-    },
+    input = {},
     picker = {},
     notifier = {},
   },

--- a/modules/home-manager/terminal/editors/nvim/config/lua/sebas/plugins/treesitter.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/lua/sebas/plugins/treesitter.lua
@@ -6,6 +6,7 @@ return {
     lazy = false,
     config = function()
       vim.api.nvim_create_autocmd('FileType', {
+        group = vim.api.nvim_create_augroup('nvim-treesitter-ft', { clear = true }),
         callback = function()
           if vim.treesitter.language.get_lang(vim.bo.filetype) then
             pcall(vim.treesitter.start)
@@ -64,11 +65,11 @@ return {
       end, { desc = 'Select [I]nside [L]oop' })
 
       vim.keymap.set({ 'x', 'o' }, 'ii', function()
-        select.select_textobject('@conditional.outer', 'textobjects')
-      end, { desc = 'Select [A]round [I]f conditional' })
-      vim.keymap.set({ 'x', 'o' }, 'ai', function()
         select.select_textobject('@conditional.inner', 'textobjects')
       end, { desc = 'Select [I]nside [I]f conditional' })
+      vim.keymap.set({ 'x', 'o' }, 'ai', function()
+        select.select_textobject('@conditional.outer', 'textobjects')
+      end, { desc = 'Select [A]round [I]f conditional' })
 
       vim.keymap.set({ 'x', 'o' }, 'as', function()
         select.select_textobject('@local.scope', 'locals')
@@ -129,12 +130,12 @@ return {
         move.goto_previous_end('@class.outer', 'textobjects')
       end, { desc = 'Previous [C]lass end' })
 
-      vim.keymap.set({ 'n', 'x', 'o' }, ']d', function()
+      vim.keymap.set({ 'n', 'x', 'o' }, ']i', function()
         move.goto_next('@conditional.outer', 'textobjects')
-      end, { desc = 'Next con[D]itional' })
-      vim.keymap.set({ 'n', 'x', 'o' }, '[d', function()
+      end, { desc = 'Next [I]f conditional' })
+      vim.keymap.set({ 'n', 'x', 'o' }, '[i', function()
         move.goto_previous('@conditional.outer', 'textobjects')
-      end, { desc = 'Previous con[D]itional' })
+      end, { desc = 'Previous [I]f conditional' })
     end,
   },
 }

--- a/modules/home-manager/terminal/editors/nvim/config/lua/sebas/utils/ltex.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/lua/sebas/utils/ltex.lua
@@ -5,7 +5,6 @@ M.filetypes = {
   'gitcommit',
   'mail',
   'markdown',
-  'mdx',
   'org',
   'pandoc',
   'rst',

--- a/modules/home-manager/terminal/editors/nvim/config/plugin/autocmds.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/plugin/autocmds.lua
@@ -18,7 +18,6 @@ vim.api.nvim_create_autocmd('FileType', {
     'tex',
     'latex',
     'markdown',
-    'mdx',
     'org',
   },
   command = 'setlocal spell spelllang=en,es,de,sv',
@@ -35,7 +34,7 @@ vim.api.nvim_create_autocmd('FileType', {
 })
 
 -- Autosave
-local group = vim.api.nvim_create_augroup('autosave', {})
+local group = vim.api.nvim_create_augroup('autosave', { clear = true })
 
 vim.api.nvim_create_autocmd('User', {
   pattern = 'AutoSaveWritePost',

--- a/modules/home-manager/terminal/editors/nvim/config/plugin/filetypes.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/plugin/filetypes.lua
@@ -1,0 +1,7 @@
+-- Filetype registrations not covered by Neovim's runtime defaults.
+vim.filetype.add {
+  extension = {
+    tmpl = 'gotmpl',
+    gohtml = 'gotmpl',
+  },
+}

--- a/modules/home-manager/terminal/editors/nvim/config/plugin/keymaps.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/plugin/keymaps.lua
@@ -12,7 +12,6 @@ vim.keymap.set('n', ']d', function()
   vim.diagnostic.jump { count = 1 }
 end, { desc = 'Go to next [D]iagnostic message' })
 vim.keymap.set('n', '<leader>e', vim.diagnostic.open_float, { desc = 'Show diagnostic [E]rror messages' })
-vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, { desc = 'Open diagnostic [Q]uickfix list' })
 
 -- clipboard
 vim.keymap.set({ 'n', 'v' }, '<leader>y', '"+y', { desc = 'Copy to OS clipboard' })
@@ -43,7 +42,7 @@ vim.keymap.set({ 'n', 'v' }, '<C-x>', '<Cmd>bdelete<CR>', { desc = 'Delete curre
 
 vim.keymap.set({ 'x' }, 'p', 'pgvy', { desc = 'Retain the buffer content after pasting over a visual selection' })
 
-function ToggleQuickfix()
+local function toggle_quickfix()
   local windows = vim.fn.getwininfo()
   for _, win in ipairs(windows) do
     if win.quickfix == 1 then
@@ -54,7 +53,7 @@ function ToggleQuickfix()
   vim.cmd.copen()
 end
 
-vim.api.nvim_set_keymap('n', '<leader>q', ':lua ToggleQuickfix()<CR>', { noremap = true, silent = true })
+vim.keymap.set('n', '<leader>q', toggle_quickfix, { desc = 'Toggle [Q]uickfix list' })
 
 vim.keymap.set('n', '<leader>cp', function()
   local path = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ':.')

--- a/modules/home-manager/terminal/editors/nvim/config/plugin/options.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/plugin/options.lua
@@ -47,7 +47,6 @@ vim.opt.cursorline = true
 -- Minimal number of screen lines to keep above and below the cursor.
 vim.opt.scrolloff = 10
 
-vim.opt.signcolumn = 'yes'
 vim.opt.colorcolumn = '80,120'
 vim.opt.textwidth = 120
 


### PR DESCRIPTION
## Summary

- **sway**: add `XF86MonBrightnessUp`/`XF86MonBrightnessDown` keybindings via `brightnessctl`
- **zig**: switch zig package to master channel; add `zls` LSP config and `zig` ftplugin with auto-fix/organize-imports on save
- **nvim**: fix deprecations, bugs and warnings found during config audit

## nvim changes

- `vim.loop` → `vim.uv` (deprecated since Neovim 0.10)
- Fix `bashls` `filetypes` misplaced inside `settings` (zsh never attached)
- Remove dead `<leader>q` binding; make `toggle_quickfix` local
- Remove invalid `snacks` `input.b` config block
- Fix `]d`/`[d` conflict: rename treesitter conditional moves to `]i`/`[i`
- Fix `ii`/`ai` conditional textobject swap (outer/inner were reversed)
- Fix harpoon `<C-n>`/`<C-p>` inverted (prev/next were swapped)
- Replace `prefer_rust_with_warning` with `prefer_rust` in blink.cmp
- Extract `<F2>` keymap out of multi-event lint autocmd
- Add `clear=true` to autosave augroup; named augroup to treesitter FileType autocmd
- Remove `Comment.nvim` (redundant since Neovim 0.10 native `gc`/`gcc`)
- Remove unused `is_vscode` variable and duplicate `signcolumn` option
- Force `utf-16` position encoding globally to fix LSP mismatch warning
- Map `.mdx` extension directly to `markdown`; remove convoluted ftplugin hack
- Add `gotmpl` filetype registration