### PR TITLE
fix(nvim): silence 'no code actions' on zig save

### DIFF
--- a/modules/home-manager/develop/zig/default.nix
+++ b/modules/home-manager/develop/zig/default.nix
@@ -12,7 +12,7 @@ in
     config = with pkgs;
       lib.mkIf cfg.enable {
         home = {
-          packages = [zigpkgs.master];
+          packages = [zigpkgs.default];
         };
       };
   }

--- a/modules/home-manager/terminal/editors/nvim/config/after/ftplugin/zig.lua
+++ b/modules/home-manager/terminal/editors/nvim/config/after/ftplugin/zig.lua
@@ -1,21 +1,28 @@
--- Auto-apply all fixable zls diagnostics on save
+local function apply_code_action(kind)
+  local params = vim.lsp.util.make_range_params(0, 'utf-16')
+  params.context = { only = { kind }, diagnostics = {} }
+  local results = vim.lsp.buf_request_sync(0, 'textDocument/codeAction', params, 500)
+  for _, res in pairs(results or {}) do
+    for _, action in pairs(res.result or {}) do
+      if action.edit then
+        vim.lsp.util.apply_workspace_edit(action.edit, 'utf-16')
+      elseif type(action.command) == 'table' then
+        vim.lsp.buf.execute_command(action.command)
+      end
+    end
+  end
+end
+
 vim.api.nvim_create_autocmd('BufWritePre', {
   buffer = 0,
   callback = function()
-    vim.lsp.buf.code_action {
-      context = { only = { 'source.fixAll' }, diagnostics = {} },
-      apply = true,
-    }
+    apply_code_action 'source.fixAll'
   end,
 })
 
--- Auto-sort imports on save
 vim.api.nvim_create_autocmd('BufWritePre', {
   buffer = 0,
   callback = function()
-    vim.lsp.buf.code_action {
-      context = { only = { 'source.organizeImports' }, diagnostics = {} },
-      apply = true,
-    }
+    apply_code_action 'source.organizeImports'
   end,
 })


### PR DESCRIPTION
## Summary

- Replace `vim.lsp.buf.code_action { apply = true }` with a direct `buf_request_sync` call in `after/ftplugin/zig.lua` — when zls returns no matching actions the loop is a no-op and no notification is shown
- Revert `zigpkgs.master` → `zigpkgs.default` to avoid zls version mismatch with stable Zig

## Test plan

- [x] Open a zig file and save — no "No code actions available" notification
- [x] Introduce a fixable diagnostic, save — zls auto-fixes it silently
- [x] Confirm zls version matches Zig version (no version mismatch warning on file open)