### PR TITLE
config(locale): Change timezone to Buenos Aires

### DIFF
--- a/modules/nixos/global/locale.nix
+++ b/modules/nixos/global/locale.nix
@@ -12,6 +12,7 @@
         "sv_SE.UTF-8/UTF-8"
       ];
     };
-    time.timeZone = lib.mkDefault "Europe/Stockholm";
+    time.timeZone = lib.mkDefault "America/Buenos_Aires";
+    # time.timeZone = lib.mkDefault "Europe/Stockholm";
   };
 }


### PR DESCRIPTION
## Summary
- Change timezone from Europe/Stockholm to America/Buenos_Aires

## Test Plan
- [ ] Verify timezone is set correctly in generated NixOS configuration