### PR TITLE
feat(waybar): Add timezone toggle button

### DIFF
--- a/modules/home-manager/desktop/wayland/compositors/hyprland/default.nix
+++ b/modules/home-manager/desktop/wayland/compositors/hyprland/default.nix
@@ -199,6 +199,8 @@ in
             "float,class:^(.blueman-manager-wrapped)$"
             "float,class:^(transmission-qt)$"
 
+            "float,title:^timezone-toggle$"
+
             "float,class:^(org.pulseaudio.pavucontrol)$"
 
             "float,title:Meeting chat,class:zoom"

--- a/modules/home-manager/desktop/wayland/compositors/sway/floating-criteria.nix
+++ b/modules/home-manager/desktop/wayland/compositors/sway/floating-criteria.nix
@@ -24,6 +24,7 @@ _: {
       {app_id = ".blueman-manager-wrapped";}
       {app_id = "transmission-qt";}
       {app_id = "floating-terminal";}
+      {title = "timezone-toggle";}
       {
         class = "jetbrains-idea-ce";
         title = "Welcome to IntelliJ IDEA";

--- a/modules/home-manager/desktop/wayland/waybar/default.nix
+++ b/modules/home-manager/desktop/wayland/waybar/default.nix
@@ -8,6 +8,60 @@
   pavucontrol = lib.getExe pkgs.pavucontrol;
   blueman = "${pkgs.blueman}/bin/blueman-manager";
   swayNcClient = "${pkgs.swaynotificationcenter}/bin/swaync-client";
+
+  # Timezone switch scripts (wrapper scripts to avoid quoting issues)
+  tzSwitchAR = pkgs.writeShellScriptBin "tz-switch-ar" ''
+    echo "Switching timezone to Buenos Aires..."
+    sudo timedatectl set-timezone America/Buenos_Aires
+  '';
+
+  tzSwitchSE = pkgs.writeShellScriptBin "tz-switch-se" ''
+    echo "Switching timezone to Stockholm..."
+    sudo timedatectl set-timezone Europe/Stockholm
+  '';
+
+  # Terminal launcher function
+  terminalLauncher = scriptPath:
+    if config.desktop.terminal.foot.enable
+    then "${pkgs.foot}/bin/foot -T timezone-toggle -e ${scriptPath}"
+    else if config.desktop.terminal.wezterm.enable
+    then "${pkgs.wezterm}/bin/wezterm start --class timezone-toggle -- ${scriptPath}"
+    else throw "waybar timezone module requires either foot or wezterm to be enabled";
+
+  # Timezone check script
+  tzCheckScript = pkgs.writeShellScriptBin "waybar-timezone-check" ''
+    current_tz=$(timedatectl show --property=Timezone --value 2>/dev/null || echo "")
+
+    case "$current_tz" in
+      "Europe/Stockholm")
+        echo "🇸🇪 SE"
+        ;;
+      "America/Buenos_Aires")
+        echo "🇦🇷 AR"
+        ;;
+      *)
+        echo "??"
+        ;;
+    esac
+  '';
+
+  # Timezone toggle script
+  tzToggleScript = pkgs.writeShellScriptBin "waybar-timezone-toggle" ''
+    current_tz=$(timedatectl show --property=Timezone --value 2>/dev/null || echo "")
+    notify="${pkgs.libnotify}/bin/notify-send"
+
+    case "$current_tz" in
+      "America/Buenos_Aires")
+        ${terminalLauncher "${tzSwitchSE}/bin/tz-switch-se"}
+        $notify "Timezone Changed" "Switched to Stockholm"
+        ;;
+      *)
+        # Default to Buenos Aires (handles Stockholm and unknown timezones)
+        ${terminalLauncher "${tzSwitchAR}/bin/tz-switch-ar"}
+        $notify "Timezone Changed" "Switched to Buenos Aires"
+        ;;
+    esac
+  '';
 in
   with lib; {
     options.desktop.wayland.waybar.enable = mkEnableOption "waybar";
@@ -59,6 +113,8 @@ in
               "idle_inhibitor"
               "custom/sep"
               "clock"
+              "custom/sep"
+              "custom/timezone-toggle"
               "custom/sep"
               "tray"
               "custom/sep"
@@ -237,6 +293,12 @@ in
             disk = {
               format = " {free}";
               interval = "30";
+            };
+
+            "custom/timezone-toggle" = {
+              exec = "${tzCheckScript}/bin/waybar-timezone-check";
+              interval = 30;
+              on-click = "${tzToggleScript}/bin/waybar-timezone-toggle";
             };
 
             "custom/notifications" = {

--- a/modules/nixos/global/locale.nix
+++ b/modules/nixos/global/locale.nix
@@ -12,7 +12,7 @@
         "sv_SE.UTF-8/UTF-8"
       ];
     };
-    time.timeZone = lib.mkDefault "America/Buenos_Aires";
-    # time.timeZone = lib.mkDefault "Europe/Stockholm";
+    time.timeZone = lib.mkDefault "Europe/Stockholm";
+    # time.timeZone = lib.mkDefault "America/Buenos_Aires";
   };
 }


### PR DESCRIPTION
## Summary

Add a clickable waybar button to toggle between timezones:
- 🇸🇪 SE (Europe/Stockholm) - **Default/System timezone**
- 🇦🇷 AR (America/Buenos_Aires)

## Changes

### Waybar Timezone Toggle
- **Toggle button**: Shows current timezone, click to switch to the other
- **Floating terminal**: Opens as a floating window (title: `timezone-toggle`)
- **Auto-close**: Terminal closes immediately after timezone change
- **Desktop notification**: Shows confirmation after switching
- **30-second refresh**: Button updates to reflect current timezone
- **Terminal detection**: Automatically uses foot or wezterm
- **Build-time validation**: Fails at build time if no supported terminal is enabled

### System Timezone
- Changed default system timezone from America/Buenos_Aires to Europe/Stockholm
- Sweden/Stockholm is now the system default and the waybar toggle default

## Implementation Details

- **Separate wrapper scripts**: `tz-switch-ar` and `tz-switch-se` to avoid shell quoting issues
- **Window rules**: Added floating window rules for Sway and Hyprland
- **Terminal commands**:
  - foot: `foot -T timezone-toggle -e /path/to/script`
  - wezterm: `wezterm start --class timezone-toggle -- /path/to/script`

## Button Placement

Located on the right side of waybar between the clock and tray modules.

## Usage

Click the timezone button in waybar to toggle between Stockholm (default) and Buenos Aires timezones. The terminal opens briefly to execute the change, then closes automatically, and a notification confirms the switch.

## Test Plan

- [ ] Build succeeds with foot enabled
- [ ] Build succeeds with wezterm enabled
- [ ] Build fails with descriptive error if neither is enabled
- [ ] Clicking button opens floating terminal
- [ ] Timezone changes successfully
- [ ] Terminal closes automatically
- [ ] Notification appears after timezone change
- [ ] Button display updates to reflect new timezone
- [ ] System timezone is set to Europe/Stockholm on rebuild